### PR TITLE
feat: #2 make conv return scalar

### DIFF
--- a/lib/Class/Measure.pm
+++ b/lib/Class/Measure.pm
@@ -300,7 +300,7 @@ sub _conv {
     foreach $unit (@$path){
         my $conv = $units->{$prev_unit}->{$unit};
         if( ref($conv) ){
-            $value = \&{$conv}( $value, $prev_unit, $unit );
+            $value = &{$conv}( $value, $prev_unit, $unit );
         }else{
             $value = $value * $units->{$prev_unit}->{$unit};
         }

--- a/t/conv_via_sub.t
+++ b/t/conv_via_sub.t
@@ -1,0 +1,20 @@
+#!/usr/bin/env perl
+use 5.008001;
+use strict;
+use warnings;
+use Test2::V0;
+
+use Class::Measure;
+
+{ package MeasureTest; use base qw( Class::Measure ); }
+
+MeasureTest->reg_units(
+    qw(example1 example2)
+);
+MeasureTest->reg_convs(
+    'example1' => 'example2', sub { return shift },
+);
+my $example = MeasureTest->new(1, 'example1');
+ok( ($example->example2 == 1), 'convert via sub');
+
+done_testing;


### PR DESCRIPTION
While working on my subclass Class::Measure::Scientific::FX_992vb https://bitbucket.org/rolandvanipenburg/class-measure-scientific-fx_992vb/src/develop/ I noticed the subs I use to convert temperatures returned scalar refs while the straight conversions return scalars. This change makes the returned values always scalars.